### PR TITLE
Revert the BigWig change that was incorrectly changed...

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -90,7 +90,7 @@
   "distributions": [
     {
       "formats": [
-        "BigWig"
+        "bigWig"
       ],
       "size": 457,
       "unit": {


### PR DESCRIPTION
@zxenia very sorry... Emmet told me that the correct convention for bigWig was bigWig and not BigWig. This change the format back to bigWig in the DATS.json file