### PR TITLE
Modify the date type to comply with convention

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -5,7 +5,7 @@
     {
       "date": "2020-01-22 00:00:00",
       "type": {
-        "value": "CONP DATS fileset creation date"
+        "value": "CONP DATS JSON fileset creation date"
       }
     }
   ],


### PR DESCRIPTION
This fixes the value of the date type to comply with convention: date type should be all lower case with the exception of CONP DATS JSON fileset creation date.

Flagged by the validator modifications to check date types: https://github.com/CONP-PCNO/conp-dataset/pull/519